### PR TITLE
Fixes binary processing not working properly

### DIFF
--- a/src/main/java/com/algorithmia/development/Response.java
+++ b/src/main/java/com/algorithmia/development/Response.java
@@ -20,7 +20,7 @@ class Response {
             } else if (data.getClass() == String.class) {
                 contentType = "text";
                 jsonData = gson.toJsonTree(data);
-            } else if (data.getClass() == byte.class) {
+            } else if (data.getClass() == byte[].class) {
                 contentType = "binary";
                 jsonData = gson.toJsonTree(Base64.encodeBase64String((byte[]) data));
 
@@ -28,7 +28,6 @@ class Response {
                 contentType = "json";
                 jsonData = gson.toJsonTree(data);
             }
-
             metaData = new MetaData(contentType);
             result = jsonData;
         } catch (StackOverflowError | java.lang.IllegalArgumentException e) {
@@ -42,6 +41,7 @@ class Response {
         metaData.addProperty("content_type", this.metaData.content_type);
         node.add("metadata", metaData);
         node.add("result", gson.toJsonTree(this.result));
+        System.out.println(node.toString());
         return node.toString();
     }
 

--- a/src/test/java/algorithms/BinaryAbstractAlgorithm.java
+++ b/src/test/java/algorithms/BinaryAbstractAlgorithm.java
@@ -2,8 +2,8 @@ package algorithms;
 
 import com.algorithmia.development.AbstractAlgorithm;
 
-public class BinaryAbstractAlgorithm extends AbstractAlgorithm<byte[], String> {
-     public  String apply(byte[] input) {
-        return new String(input);
+public class BinaryAbstractAlgorithm extends AbstractAlgorithm<byte[], byte[]> {
+     public  byte[] apply(byte[] input) {
+        return input;
     }
 }

--- a/src/test/java/loaders/Binary.java
+++ b/src/test/java/loaders/Binary.java
@@ -33,12 +33,12 @@ public class Binary extends AbstractLoader{
     }
 
     public JsonObject GenerateOutput() {
-        String outputObj = "This is a test";
+        byte[] outputObj = ("This is a test").getBytes();
         JsonObject expectedResponse = new JsonObject();
         JsonObject metadata = new JsonObject();
-        metadata.addProperty("content_type", "text");
+        metadata.addProperty("content_type", "binary");
         expectedResponse.add("metadata", metadata);
-        expectedResponse.addProperty("result", outputObj);
+        expectedResponse.add("result", gson.toJsonTree(Base64.encodeBase64String(outputObj)));
         return expectedResponse;
     }
 


### PR DESCRIPTION
Fixes an issue where binary data getting returned as a byte[] object would get processed as json rather than base64 encoded strings, and with an incorrect content type. Adjusted existing unit test to capture this in the future.